### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .vscode/
+.zed/
 
-# Certificates 
+# Certificates
 birdhouse-key.key
 birdhouse-certificate.crt

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e7b8ee154e614cfca71c27571a87f67694c0f6af50070808eaede918a3267847",
+  "originHash" : "e2673cacc58fc05145c1ee91ee9ebbf7cb5a84acf64ac32a9e468bf37d75db26",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird.git",
       "state" : {
-        "revision" : "0e6de7141f4feda30c319c1a14047b7057f38db5",
-        "version" : "2.0.0-rc.1"
+        "revision" : "3c277235f259846ad09fcba7c8d901db12e9faf2",
+        "version" : "2.2.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
-        "version" : "1.4.0"
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "da4e36f86544cdf733a40d59b3a2267e3a7bbf36",
-        "version" : "1.0.0"
+        "revision" : "5c8bd186f48c16af0775972700626f0b74588278",
+        "version" : "1.0.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
-        "revision" : "1ddbea1ee34354a6a2532c60f98501c35ae8edfa",
-        "version" : "1.2.0"
+        "revision" : "ae67c8178eb46944fd85e4dc6dd970e1f3ed6ccd",
+        "version" : "1.3.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-        "version" : "1.5.4"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "971ba26378ab69c43737ee7ba967a896cb74c0d1",
-        "version" : "2.4.1"
+        "revision" : "e0165b53d49b413dd987526b641e05e246782685",
+        "version" : "2.5.0"
       }
     },
     {
@@ -182,30 +182,12 @@
       }
     },
     {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
-        "version" : "600.0.0-prerelease-2024-06-12"
-      }
-    },
-    {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
         "revision" : "025bcb1165deab2e20d4eaba79967ce73013f496",
         "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-testing",
-      "state" : {
-        "revision" : "69d59cfc76e5daf498ca61f5af409f594768eef9",
-        "version" : "0.10.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -4,16 +4,15 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftBirdhouse",
-    platforms: [ .macOS(.v14) ],
+    platforms: [.macOS(.v14)],
     products: [
-        .executable(name: "birdhouse", targets: ["Birdhouse"]),
+        .executable(name: "birdhouse", targets: ["Birdhouse"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.4.0"),
-        .package(url: "https://github.com/apple/swift-http-types", from: "1.2.0"),
-        .package(url: "https://github.com/apple/swift-log", from: "1.5.4"),
-        .package(url: "https://github.com/apple/swift-testing", from: "0.10.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird", from: "2.0.0-rc.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-http-types", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-log", from: "1.6.1"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird", from: "2.2.0"),
         .package(url: "https://github.com/vapor/multipart-kit", from: "4.7.0"),
         .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.19"),
     ],
@@ -31,7 +30,7 @@ let package = Package(
                 .product(name: "ZIPFoundation", package: "ZIPFoundation"),
             ],
             swiftSettings: [
-                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release)),
+                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
             ]
         ),
         .testTarget(
@@ -40,8 +39,7 @@ let package = Package(
                 .byName(name: "Birdhouse"),
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "HummingbirdTesting", package: "hummingbird"),
-                .product(name: "Testing", package: "swift-testing"),
             ]
-        )
+        ),
     ]
 )

--- a/Sources/Birdhouse/RegistryController+DownloadSourceArchive.swift
+++ b/Sources/Birdhouse/RegistryController+DownloadSourceArchive.swift
@@ -3,7 +3,9 @@ import Hummingbird
 
 extension RegistryController {
 
-    @Sendable func downloadSourceArchive(request: Request, context: some RequestContext) async throws -> EditedResponse<ByteBuffer> {
+    @Sendable func downloadSourceArchive(request: Request, context: some RequestContext)
+        async throws -> EditedResponse<ByteBuffer>
+    {
         let scope = try context.parameters.require("scope")
         let name = try context.parameters.require("name")
         let version = try context.parameters.require("version")
@@ -14,14 +16,14 @@ extension RegistryController {
             throw HTTPError(.notFound)
         }
 
-        let byteBuffer = context.allocator.buffer(data: release.sourceArchive)
+        let byteBuffer = ByteBuffer(bytes: release.sourceArchive)
 
         return EditedResponse(
             status: .ok,
             headers: [
                 .contentType: "application/zip",
                 .contentVersion: "1",
-                .contentDisposition: "attachment; filename=\"\(release.sourceArchiveName)\""
+                .contentDisposition: "attachment; filename=\"\(release.sourceArchiveName)\"",
             ],
             response: byteBuffer
         )


### PR DESCRIPTION
Update dependencies to the latest versions.
Also remove the swift-testing dependency as it has been incorporated into the Swift Toolkit.